### PR TITLE
Fix the bug in the keep_send function that causes it to be called onl…

### DIFF
--- a/src/LeftVboxCall.c
+++ b/src/LeftVboxCall.c
@@ -264,10 +264,11 @@ on_hex_send_toggled (GtkToggleButton *togglebutton, gpointer user_data)
 		is_hex_send = 0;
 }
 
-void *keep_send(struct xcomdata *xcomdata)
+gboolean keep_send(struct xcomdata *xcomdata)
 {	
 	send_data(xcomdata);
 	debug_p("keep send\n");	
+	return G_SOURCE_CONTINUE; 
 }
 
 void


### PR DESCRIPTION
定时器工作机制：
g_timeout_add 函数设置的定时器默认是一次性定时器，除非回调函数返回 G_SOURCE_CONTINUE 或者 TRUE，否则只会执行一次。
修改keep_send函数的类型，默认返回：G_SOURCE_CONTINUE